### PR TITLE
Resolve #53 "Use `generator-example` as default alias"

### DIFF
--- a/src/lib/tasks/prompt.js
+++ b/src/lib/tasks/prompt.js
@@ -31,7 +31,7 @@ export default app => {
 
     app.question('alias', {
       message: 'Generator alias ?',
-      default: 'my-generator'
+      default: 'generator-example'
     })
     askPromise(['alias'])
     .then(({alias}) => {


### PR DESCRIPTION
Resolve #53